### PR TITLE
Add a bunch of packages

### DIFF
--- a/.github/workflows/repackage.yaml
+++ b/.github/workflows/repackage.yaml
@@ -32,6 +32,7 @@ jobs:
       - name: Install Packages
         run: make "-j$(nproc)" install
       - name: Upload Packages
+        if: github.event_name != 'pull_request' && github.ref_name == 'main'
         uses: actions/upload-artifact@v4
         with:
           path: build/
@@ -42,8 +43,8 @@ jobs:
 
   publish:
     name: 🍱 Publish Packages
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
-    runs-on: ubuntu-${{ matrix.arch[1] == 'arm64' && '24.04-arm' || 'latest' }}
+    if: github.event_name != 'pull_request' && github.ref_name == 'main'
+    runs-on: ubuntu-latest
     needs: repackage
     steps:
       - name: Download Packages

--- a/bin/repackage
+++ b/bin/repackage
@@ -59,8 +59,7 @@ parse_deb() {
 # appear in a directory with the package name.
 unpack() {
 	local pkg=$1
-	local deb="${pkg}_${version}_${arch}.deb"
-	dpkg-deb -R "$deb" "$pkg"
+	dpkg-deb -R "${pkg}_"*.deb "$pkg"
 }
 
 # copy_files copies all the .so files and symlinks and the copyright file from

--- a/packages/libboost-serialization.cfg
+++ b/packages/libboost-serialization.cfg
@@ -1,0 +1,2 @@
+noble_package=libboost-serialization1.83.0
+jammy_package=libboost-serialization1.74.0

--- a/packages/libbrotli.cfg
+++ b/packages/libbrotli.cfg
@@ -1,0 +1,2 @@
+noble_package=libbrotli1
+jammy_package=libbrotli1

--- a/packages/libcurl.cfg
+++ b/packages/libcurl.cfg
@@ -1,0 +1,4 @@
+noble_package=libcurl4t64
+jammy_package=libcurl4
+
+# Dependencies: libbrotli1, libldap2, libnghttp2, libpsl5t64, librtmp1, libssh-4

--- a/packages/libgeos-c.cfg
+++ b/packages/libgeos-c.cfg
@@ -1,0 +1,2 @@
+noble_package=libgeos-c1t64
+jammy_package=libgeos-c1v5

--- a/packages/libldap.cfg
+++ b/packages/libldap.cfg
@@ -1,0 +1,2 @@
+noble_package=libldap2
+jammy_package=libldap-2.5-0

--- a/packages/libmariadbd.cfg
+++ b/packages/libmariadbd.cfg
@@ -1,0 +1,2 @@
+noble_package=libmariadbd19t64
+jammy_package=libmariadbd19

--- a/packages/libmysqlclient.cfg
+++ b/packages/libmysqlclient.cfg
@@ -1,0 +1,2 @@
+noble_package=libmysqlclient21
+jammy_package=libmysqlclient21

--- a/packages/libnghttp.cfg
+++ b/packages/libnghttp.cfg
@@ -1,0 +1,2 @@
+noble_package=libnghttp2-14
+jammy_package=libnghttp2-14

--- a/packages/libprotobuf-c.cfg
+++ b/packages/libprotobuf-c.cfg
@@ -1,0 +1,2 @@
+noble_package=libprotobuf-c1
+jammy_package=libprotobuf-c1

--- a/packages/libpsl.cfg
+++ b/packages/libpsl.cfg
@@ -1,0 +1,2 @@
+noble_package=libpsl5t64
+jammy_package=libpsl5

--- a/packages/librtmp.cfg
+++ b/packages/librtmp.cfg
@@ -1,0 +1,2 @@
+noble_package=librtmp1
+jammy_package=librtmp1

--- a/packages/libssh.cfg
+++ b/packages/libssh.cfg
@@ -1,0 +1,2 @@
+noble_package=libssh-4
+jammy_package=libssh-4

--- a/packages/libsybdb.cfg
+++ b/packages/libsybdb.cfg
@@ -1,0 +1,2 @@
+noble_package=libsybdb5
+jammy_package=libsybdb5

--- a/packages/libtcl.cfg
+++ b/packages/libtcl.cfg
@@ -1,0 +1,2 @@
+noble_package=libtcl8.6
+jammy_package=libtcl8.6


### PR DESCRIPTION
Accounts for a significant percentage of the dependencies we use. Also tweak `repackage` to be less fussy about the `.deb` file name, as certain characters in version, at least, can end up URL encoded in the file name.

Also, teach the Tembox workflow to publish artifacts only on main.