### PR TITLE
Add comment with dependencies for each package

### DIFF
--- a/packages/libboost-serialization.cfg
+++ b/packages/libboost-serialization.cfg
@@ -1,2 +1,4 @@
 noble_package=libboost-serialization1.83.0
 jammy_package=libboost-serialization1.74.0
+
+# Depends: libc, libgcc-s1, libstdc++

--- a/packages/libbrotli.cfg
+++ b/packages/libbrotli.cfg
@@ -1,2 +1,4 @@
 noble_package=libbrotli1
 jammy_package=libbrotli1
+
+# Depends: libc

--- a/packages/libbson.cfg
+++ b/packages/libbson.cfg
@@ -1,2 +1,4 @@
 noble_package=libbson-1.0-0t64
 jammy_package=libbson-1.0-0
+
+# Depends: libc

--- a/packages/libcurl.cfg
+++ b/packages/libcurl.cfg
@@ -1,4 +1,4 @@
 noble_package=libcurl4t64
 jammy_package=libcurl4
 
-# Dependencies: libbrotli1, libldap2, libnghttp2, libpsl5t64, librtmp1, libssh-4
+# Depends: libc, libbrotli, libgssapi-krb5, libidn, libldap, libnghttp2, libpsl, librtmp), libssh, libssl3, libzstd, zlib1

--- a/packages/libgeos-c.cfg
+++ b/packages/libgeos-c.cfg
@@ -1,2 +1,4 @@
 noble_package=libgeos-c1t64
 jammy_package=libgeos-c1v5
+
+# Depends: libc, libgcc-s, libgeos, libstdc++

--- a/packages/libgeos.cfg
+++ b/packages/libgeos.cfg
@@ -1,2 +1,4 @@
 noble_package=libgeos3.12.1t64
 jammy_package=libgeos3.10.2
+
+# Depends: libc, libgcc-s, libstdc++

--- a/packages/libgomp.cfg
+++ b/packages/libgomp.cfg
@@ -1,2 +1,4 @@
 noble_package=libgomp1
 jammy_package=libgomp1
+
+# Depends: gcc-14-base, libc

--- a/packages/libhiredis.cfg
+++ b/packages/libhiredis.cfg
@@ -1,2 +1,4 @@
 noble_package=libhiredis1.1.0
 jammy_package=libhiredis0.14
+
+# Depends: libc, libssl3

--- a/packages/libjson-c.cfg
+++ b/packages/libjson-c.cfg
@@ -1,2 +1,4 @@
 noble_package=libjson-c5
 jammy_package=libjson-c5
+
+# Depends: libc

--- a/packages/libldap.cfg
+++ b/packages/libldap.cfg
@@ -1,2 +1,4 @@
 noble_package=libldap2
 jammy_package=libldap-2.5-0
+
+# Depends: libc, libgnutls3, libsasl2

--- a/packages/libmariadbd.cfg
+++ b/packages/libmariadbd.cfg
@@ -1,2 +1,4 @@
 noble_package=libmariadbd19t64
 jammy_package=libmariadbd19
+
+# Depends: libc libcrypt, libgcc-s, libnuma, libpcre2, libssl3, libstdc++, liburing, zlib1

--- a/packages/libmpfr.cfg
+++ b/packages/libmpfr.cfg
@@ -1,2 +1,4 @@
 noble_package=libmpfr6
 jammy_package=libmpfr6
+
+# Depends: libc, libgmp

--- a/packages/libmysqlclient.cfg
+++ b/packages/libmysqlclient.cfg
@@ -1,2 +1,4 @@
 noble_package=libmysqlclient21
 jammy_package=libmysqlclient21
+
+# Depends: mysql-common, libc, libgcc-s, libssl3, libstdc++, libzstd, zlib1

--- a/packages/libnghttp2.cfg
+++ b/packages/libnghttp2.cfg
@@ -1,2 +1,4 @@
 noble_package=libnghttp2-14
 jammy_package=libnghttp2-14
+
+# Depends: libc

--- a/packages/libprotobuf-c.cfg
+++ b/packages/libprotobuf-c.cfg
@@ -1,2 +1,4 @@
 noble_package=libprotobuf-c1
 jammy_package=libprotobuf-c1
+
+# Depends: libc

--- a/packages/libpsl.cfg
+++ b/packages/libpsl.cfg
@@ -1,2 +1,4 @@
 noble_package=libpsl5t64
 jammy_package=libpsl5
+
+# Depends: libidn2, libc, libunistring5

--- a/packages/librdkafka.cfg
+++ b/packages/librdkafka.cfg
@@ -1,2 +1,4 @@
 noble_package=librdkafka1
 jammy_package=librdkafka1
+
+# Depends: libc, liblz4, libsasl2, libssl3, libzstd, zlib1

--- a/packages/librtmp.cfg
+++ b/packages/librtmp.cfg
@@ -1,2 +1,4 @@
 noble_package=librtmp1
 jammy_package=librtmp1
+
+# Depends: libc, libgmp, libgnutls3, libhogweed, libnettle8, zlib1

--- a/packages/libsfcgal.cfg
+++ b/packages/libsfcgal.cfg
@@ -1,4 +1,4 @@
 noble_package=libsfcgal1t64
 jammy_package=libsfcgal1
 
-# libmpfr6
+# Depends: libboost-serialization, libc, libgcc-s, libgmp10, libgmpxx4ldbl, libmpfr6, libstdc++

--- a/packages/libsodium.cfg
+++ b/packages/libsodium.cfg
@@ -1,2 +1,4 @@
 noble_package=libsodium23
 jammy_package=libsodium23
+
+# Depends: libc

--- a/packages/libssh.cfg
+++ b/packages/libssh.cfg
@@ -1,2 +1,4 @@
 noble_package=libssh-4
 jammy_package=libssh-4
+
+# Depends: libc, libgssapi-krb5, libssl3, zlib1

--- a/packages/libsybdb.cfg
+++ b/packages/libsybdb.cfg
@@ -1,2 +1,4 @@
 noble_package=libsybdb5
 jammy_package=libsybdb5
+
+# Depends: libc, libgmp10, libgnutls3, libgssapi-krb5, libhogweed6, libnettle8, freetds-common

--- a/packages/libtcl.cfg
+++ b/packages/libtcl.cfg
@@ -1,2 +1,4 @@
 noble_package=libtcl8.6
 jammy_package=libtcl8.6
+
+# Depends: tzdata, libc, zlib1

--- a/packages/liburiparser.cfg
+++ b/packages/liburiparser.cfg
@@ -1,2 +1,4 @@
 noble_package=liburiparser1
 jammy_package=liburiparser1
+
+# Depends: libc


### PR DESCRIPTION
Derived by running `apt info $name | grep Depends` for each on Noble. Most of those without a corresponding .cfg file are included in the Tembo Postgres base image.